### PR TITLE
Added support for Symfony 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This bundle adds privacy cookie banner into Symfony 2 application.
 
 ## Requirements
 
-- Symfony v2.6 or later
+- Symfony v2.6 or later (including Symfony 3.x)
 
 ## Installation
 This package is available via Composer, so the instructions below are similar to how you install any other open source Symfony Bundle.
@@ -21,7 +21,10 @@ Enable the bundle in `app/AppKernel.php` file:
 ```php
 $bundles = array(
     // existing bundles
-    new EzSystems\PrivacyCookieBundle\EzSystemsPrivacyCookieBundle()
+    new EzSystems\PrivacyCookieBundle\EzSystemsPrivacyCookieBundle(),
+
+    // starting from Symfony 2.8 you have to enable AsseticBundle manually if you haven't done it before
+    new Symfony\Bundle\AsseticBundle\AsseticBundle()
 );
 ```
 
@@ -37,10 +40,42 @@ bundles/ezsystemsprivacycookie/css/privacycookie.css
 bundles/ezsystemsprivacycookie/js/privacycookie.js
 ```
 
-If you are installing bundle via `composer require` you must also copy assets to your project `web` directory. You can do this by calling Symfony built-in command from the project root directory:
+Add the following minimal configuration in `config.yml` file to enable `Assetic` support in your application (Symfony 2.8 and later):
+
+```yaml
+assetic:
+    debug: '%kernel.debug%'
+    use_controller: '%kernel.debug%'
+    filters:
+        cssrewrite: ~
+```
+
+If you are installing the bundle via `composer require` you must also copy assets to your project's `web` directory. You can do this by calling Symfony's built-in command from the project root directory:
+
+For Symfony 2.x:
 
 ```bash
 php app/console assets:install --symlink
+```
+
+For Symfony 3.x:
+
+```bash
+php bin/console assets:install --symlink
+```
+
+In production environment you have to dump assets using `Assetic` built-in command:
+
+For Symfony 2.x:
+
+```bash
+php app/console assetic:dump -e=prod
+```
+
+For Symfony 3.x:
+
+```bash
+php bin/console assetic:dump -e=prod
 ```
 
 ## Usage

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,26 +6,26 @@ parameters:
 
 services:
     ez_privacy_cookie.banner_options:
-        class: %ez_privacy_cookie.banner_options.class%
+        class: '%ez_privacy_cookie.banner_options.class%'
 
     ez_privacy_cookie.twig_extension:
-        class: %ez_privacy_cookie.twig_extension.class%
+        class: '%ez_privacy_cookie.twig_extension.class%'
         arguments:
-            - @ez_privacy_cookie.banner_options
-            - @ez_privacy_cookie.banner_factory
+            - '@ez_privacy_cookie.banner_options'
+            - '@ez_privacy_cookie.banner_factory'
         tags:
             - { name: twig.extension }
 
     ez_privacy_cookie.banner_factory:
-        class: %ez_privacy_cookie.banner_factory.class%
+        class: '%ez_privacy_cookie.banner_factory.class%'
         alias: ez_privacy_cookie.configuration_banner_factory
 
     ez_privacy_cookie.configuration_banner_factory:
-        class: %ez_privacy_cookie.configuration_banner_factory.class%
-        factory: ["%ez_privacy_cookie.configuration_banner_factory.class%", build]
+        class: '%ez_privacy_cookie.configuration_banner_factory.class%'
+        factory: ['%ez_privacy_cookie.configuration_banner_factory.class%', build]
         arguments:
-            - cookie_name: %ez_privacy_cookie.cookie_name%
-              cookie_validity: %ez_privacy_cookie.days%
-              banner_caption: %ez_privacy_cookie.banner_caption%
-              banner_link_text: %ez_privacy_cookie.banner_link_text%
-              banner_link_url: %ez_privacy_cookie.banner_link_url%
+            - cookie_name: '%ez_privacy_cookie.cookie_name%'
+              cookie_validity: '%ez_privacy_cookie.days%'
+              banner_caption: '%ez_privacy_cookie.banner_caption%'
+              banner_link_text: '%ez_privacy_cookie.banner_link_text%'
+              banner_link_url: '%ez_privacy_cookie.banner_link_url%'

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ezsystems/privacy-cookie-bundle",
     "description": "Privacy cookie banner integration bundle into regular Symfony 2.x application (supports eZ Publish/eZ Platform)",
-    "keywords": ["cookies", "privacy", "policy", "symfony", "ezpublish", "ezplatform"],
+    "keywords": ["cookies", "privacy", "policy", "symfony", "ezpublish", "ezplatform", "twig"],
     "license": "GPL-2.0",
     "authors": [
         {
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "symfony/symfony": "~2.6"
+        "symfony/symfony": "^2.6|^3.0",
+        "symfony/assetic-bundle": "^2.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds support for Symfony 3.x (tested with Sf 3.1.2) in response to Olivia's request (https://github.com/ezsystems/EzSystemsPrivacyCookieBundle/issues/14)
