### PR TITLE
Trying to fix JS syntax errors on cookiePath option

### DIFF
--- a/Resources/views/privacycookie.html.twig
+++ b/Resources/views/privacycookie.html.twig
@@ -21,7 +21,7 @@
             var privacyCookieBanner = new eZ.PrivacyCookieBanner({
                 cookieName: '{{ cookieName }}',
                 days: {{ cookieValidity }},
-                path: {{ cookiePath }}
+                path: '{{ cookiePath }}'
             });
             setTimeout(function () {
                 privacyCookieBanner.show()


### PR DESCRIPTION
Currently, if the cookiePath option is null as per the configuration, we get a SyntaxError ("Unexpected token }" or "expected expression, got '}'" depending on the browser) and if it is defined (to '/' for example as in the doc) we have another SyntaxError ("invalid escape sequence" or "Invalid or unexpected token" depending on the browser). Simply escaping the value solves both cases for me.